### PR TITLE
Update to new lock_schema and cover_schema functions

### DIFF
--- a/components/secplus_gdo/cover/__init__.py
+++ b/components/secplus_gdo/cover/__init__.py
@@ -21,7 +21,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import cover
-from esphome.const import CONF_ID, CONF_TRIGGER_ID
+from esphome.const import CONF_TRIGGER_ID
 
 from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
 
@@ -41,9 +41,8 @@ CONF_PRE_CLOSE_WARNING_DURATION = "pre_close_warning_duration"
 CONF_PRE_CLOSE_WARNING_START = "pre_close_warning_start"
 CONF_PRE_CLOSE_WARNING_END = "pre_close_warning_end"
 
-CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
+CONFIG_SCHEMA = cover.cover_schema(GDODoor).extend(
     {
-        cv.GenerateID(): cv.declare_id(GDODoor),
         cv.Optional(CONF_PRE_CLOSE_WARNING_DURATION, default = "0s" ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_PRE_CLOSE_WARNING_START): automation.validate_automation(
             {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverClosingStartTrigger)}
@@ -56,9 +55,8 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = await cover.new_cover(config)
     await cg.register_component(var, config)
-    await cover.register_cover(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
     cg.add(parent.register_door(var))
     if CONF_PRE_CLOSE_WARNING_DURATION in config:

--- a/components/secplus_gdo/lock/__init__.py
+++ b/components/secplus_gdo/lock/__init__.py
@@ -18,9 +18,7 @@
  """
 
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import lock
-from esphome.const import CONF_ID
 
 from .. import SECPLUS_GDO_CONFIG_SCHEMA, secplus_gdo_ns, CONF_SECPLUS_GDO_ID
 
@@ -28,17 +26,11 @@ DEPENDENCIES = ["secplus_gdo"]
 
 GDOLock = secplus_gdo_ns.class_("GDOLock", lock.Lock, cg.Component)
 
-CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(GDOLock),
-    }
-).extend(SECPLUS_GDO_CONFIG_SCHEMA)
-
+CONFIG_SCHEMA = lock.lock_schema(GDOLock).extend(SECPLUS_GDO_CONFIG_SCHEMA)
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-    await lock.register_lock(var, config)
+    var = await lock.new_lock(config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
     cg.add(parent.register_lock(var))


### PR DESCRIPTION
https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/

ESPHome has deprecated `cover.COVER_SCHEMA` and `lock.LOCK_SCHEMA`, and they will be removed in 2025.11.0

This PR updates to the replacement `cover.cover_schema()` and `lock.lock_schema()` functions, which were added in 2025.5.0

Merging this PR will mean supporting only 2025.5.0 and later, so anyone using an older esphome release will need to either update esphome or pin to an older version of the library.